### PR TITLE
Activation

### DIFF
--- a/ReallySimpleEventing.Net40/ReallySimpleEventing.Net40.csproj
+++ b/ReallySimpleEventing.Net40/ReallySimpleEventing.Net40.csproj
@@ -48,6 +48,9 @@
     <Compile Include="..\ReallySimpleEventing\ActivationStrategies\Activator\*.cs">
       <Link>ActivationStrategies\Activator\%(FileName)</Link>
     </Compile>
+    <Compile Include="..\ReallySimpleEventing\ActivationStrategies\Composed\*.cs">
+      <Link>ActivationStrategies\Composed\%(FileName)</Link>
+    </Compile>
     <Compile Include="..\ReallySimpleEventing\ActivationStrategies\Delegated\*.cs">
       <Link>ActivationStrategies\Delegated\%(FileName)</Link>
     </Compile>

--- a/ReallySimpleEventing.Test.Unit/ActivationStrategies/Activator/DefaultActivatorTests.cs
+++ b/ReallySimpleEventing.Test.Unit/ActivationStrategies/Activator/DefaultActivatorTests.cs
@@ -10,7 +10,7 @@ using FluentAssertions;
 namespace ReallySimpleEventing.Test.Unit.ActivationStrategies.Activator
 {
     [TestFixture]
-    public class DefaultResolverTests
+    public class DefaultActivatorTests
     {
         [Test]
         public void ResolverShouldFindCorrectHandlerTypes_ExactMatch()

--- a/ReallySimpleEventing.Test.Unit/ActivationStrategies/Composed/FirstViableActivatorActivatorTests.cs
+++ b/ReallySimpleEventing.Test.Unit/ActivationStrategies/Composed/FirstViableActivatorActivatorTests.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using NUnit.Framework;
+using ReallySimpleEventing.ActivationStrategies;
+using ReallySimpleEventing.ActivationStrategies.Composed;
+using ReallySimpleEventing.EventHandling;
+
+namespace ReallySimpleEventing.Test.Unit.ActivationStrategies.Composed
+{
+    [TestFixture]
+    public class FirstViableActivatorActivatorTests
+    {
+        [Test]
+        public void WhenNoStrategIsProvided_ResolverShouldResolveEmptyResult()
+        {
+            var resolver = new FirstViableActivatorActivation(null);
+            var result = resolver.GetHandlers<SomeMessage>();
+
+            result.Should().NotBeNull();
+            result.Should().BeEmpty();
+        }
+
+        [Test]
+        public void WhenEmptyStrategyCollectionIsProvided_ResolverShouldResolveEmptyResult()
+        {
+            var resolver = new FirstViableActivatorActivation(Enumerable.Empty<IHandlerActivationStrategy>());
+            var result = resolver.GetHandlers<SomeMessage>();
+
+            result.Should().NotBeNull();
+            result.Should().BeEmpty();
+        }
+
+        [Test]
+        public void WhenNoStrategyCanResolveHandlers_ResolverShouldResolveEmptyResult()
+        {
+            var resolver = new FirstViableActivatorActivation(new[] { new HandlerActivationStrategyA() });
+            var result = resolver.GetHandlers<SomeMessage>();
+
+            result.Should().BeEmpty();
+        }
+
+        [Test]
+        public void WhenTheOnlyStrategyCanResolveHandlers_ResolverShouldReturnThoseHandlers()
+        {
+            var resolver = new FirstViableActivatorActivation(new[] { new HandlerActivationStrategyA { ShouldFindItems = true } });
+            var result = resolver.GetHandlers<SomeMessage>();
+
+            result.Count().Should().Be(1);
+            result.First().GetType().Should().Be<SomeMessageHandlerA<SomeMessage>>();
+        }
+
+        [Test]
+        public void WhenTheFirstStrategyHasAMatchingHandlerButSecondStrategyCannotMatchHandlersHandlers_ResolverShouldReturnFirstStrategiesHandlers()
+        {
+            var resolver = new FirstViableActivatorActivation(new IHandlerActivationStrategy[] { new HandlerActivationStrategyA { ShouldFindItems = true }, new HandlerActivationStrategyB { ShouldFindItems = false } });
+            var result = resolver.GetHandlers<SomeMessage>();
+
+            result.Count().Should().Be(1);
+            result.First().GetType().Should().Be<SomeMessageHandlerA<SomeMessage>>();
+        }
+
+        [Test]
+        public void WhenTheFirstStrategyCannotMatchHandlersHandlersButSecondStrategyHasAMatchingHandler_ResolverShouldReturnSecondStrategiesHandlers()
+        {
+            var resolver = new FirstViableActivatorActivation(new IHandlerActivationStrategy[] { new HandlerActivationStrategyA { ShouldFindItems = false }, new HandlerActivationStrategyB { ShouldFindItems = true } });
+            var result = resolver.GetHandlers<SomeMessage>();
+
+            result.Count().Should().Be(1);
+            result.First().GetType().Should().Be<SomeMessageHandlerB<SomeMessage>>();
+        }
+
+        [Test]
+        public void WhenTheFirstStrategyHasAMatchingHandlerAndTheSecondStrategyHasAMatchingHandler_ResolverShouldReturnFirstStrategiesHandlers()
+        {
+            var resolver = new FirstViableActivatorActivation(new IHandlerActivationStrategy[] { new HandlerActivationStrategyA { ShouldFindItems = true }, new HandlerActivationStrategyB { ShouldFindItems = true } });
+            var result = resolver.GetHandlers<SomeMessage>();
+
+            result.Count().Should().Be(1);
+            result.First().GetType().Should().Be<SomeMessageHandlerA<SomeMessage>>();
+        }
+
+
+        private class SomeMessage { }
+        private class SomeMessageHandlerA<T> : IHandle<T>
+        {
+            public void Handle(T @event) { }
+            public void OnError(T @event, Exception ex) { }
+        }
+        private class HandlerActivationStrategyA : IHandlerActivationStrategy
+        {
+            public bool ShouldFindItems { get; set; }
+
+            public IEnumerable<IHandle<TEventType>> GetHandlers<TEventType>()
+            {
+                return ShouldFindItems ? new[] { new SomeMessageHandlerA<TEventType>() } : Enumerable.Empty<IHandle<TEventType>>();
+            }
+        }
+
+        private class HandlerActivationStrategyB : IHandlerActivationStrategy
+        {
+            public bool ShouldFindItems { get; set; }
+
+            public IEnumerable<IHandle<TEventType>> GetHandlers<TEventType>()
+            {
+                return ShouldFindItems ? new[] { new SomeMessageHandlerB<TEventType>() } : Enumerable.Empty<IHandle<TEventType>>();
+            }
+        }
+        private class SomeMessageHandlerB<T> : IHandle<T>
+        {
+            public void Handle(T @event) { }
+            public void OnError(T @event, Exception ex) { }
+        }
+    }
+}

--- a/ReallySimpleEventing.Test.Unit/ActivationStrategies/Composed/UnionOfAllActivatorsActivatorTests.cs
+++ b/ReallySimpleEventing.Test.Unit/ActivationStrategies/Composed/UnionOfAllActivatorsActivatorTests.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using NUnit.Framework;
+using ReallySimpleEventing.ActivationStrategies;
+using ReallySimpleEventing.ActivationStrategies.Composed;
+using ReallySimpleEventing.EventHandling;
+
+namespace ReallySimpleEventing.Test.Unit.ActivationStrategies.Composed
+{
+    [TestFixture]
+    public class UnionOfAllActivatorsActivatorTests
+    {
+        [Test]
+        public void WhenNoStrategIsProvided_ResolverShouldResolveEmptyResult()
+        {
+            var resolver = new UnionOfAllActivatorsActivation(null);
+            var result = resolver.GetHandlers<SomeMessage>();
+
+            result.Should().NotBeNull();
+            result.Should().BeEmpty();
+        }
+
+        [Test]
+        public void WhenEmptyStrategyCollectionIsProvided_ResolverShouldResolveEmptyResult()
+        {
+            var resolver = new UnionOfAllActivatorsActivation(Enumerable.Empty<IHandlerActivationStrategy>());
+            var result = resolver.GetHandlers<SomeMessage>();
+
+            result.Should().NotBeNull();
+            result.Should().BeEmpty();
+        }
+
+        [Test]
+        public void WhenNoStrategyCanResolveHandlers_ResolverShouldResolveEmptyResult()
+        {
+            var resolver = new UnionOfAllActivatorsActivation(new[] { new HandlerActivationStrategyA() });
+            var result = resolver.GetHandlers<SomeMessage>();
+
+            result.Should().BeEmpty();
+        }
+
+        [Test]
+        public void WhenTheOnlyStrategyCanResolveHandlers_ResolverShouldReturnThoseHandlers()
+        {
+            var resolver = new UnionOfAllActivatorsActivation(new[] { new HandlerActivationStrategyA { ShouldFindItems = true } });
+            var result = resolver.GetHandlers<SomeMessage>();
+
+            result.Count().Should().Be(1);
+            result.First().GetType().Should().Be<SomeMessageHandlerA<SomeMessage>>();
+        }
+
+        [Test]
+        public void WhenTheFirstStrategyHasAMatchingHandlerButSecondStrategyCannotMatchHandlersHandlers_ResolverShouldReturnFirstStrategiesHandlers()
+        {
+            var resolver = new UnionOfAllActivatorsActivation(new IHandlerActivationStrategy[] { new HandlerActivationStrategyA { ShouldFindItems = true }, new HandlerActivationStrategyB { ShouldFindItems = false } });
+            var result = resolver.GetHandlers<SomeMessage>();
+
+            result.Count().Should().Be(1);
+            result.First().GetType().Should().Be<SomeMessageHandlerA<SomeMessage>>();
+        }
+
+        [Test]
+        public void WhenTheFirstStrategyCannotMatchHandlersHandlersButSecondStrategyHasAMatchingHandler_ResolverShouldReturnSecondStrategiesHandlers()
+        {
+            var resolver = new UnionOfAllActivatorsActivation(new IHandlerActivationStrategy[] { new HandlerActivationStrategyA { ShouldFindItems = false }, new HandlerActivationStrategyB { ShouldFindItems = true } });
+            var result = resolver.GetHandlers<SomeMessage>();
+
+            result.Count().Should().Be(1);
+            result.First().GetType().Should().Be<SomeMessageHandlerB<SomeMessage>>();
+        }
+
+        [Test]
+        public void WhenTheFirstStrategyHasAMatchingHandlerAndTheSecondStrategyHasADifferentMatchingHandler_ResolverShouldReturnBothStrategiesHandlers()
+        {
+            var resolver = new UnionOfAllActivatorsActivation(new IHandlerActivationStrategy[] { new HandlerActivationStrategyA { ShouldFindItems = true }, new HandlerActivationStrategyB { ShouldFindItems = true } });
+            var result = resolver.GetHandlers<SomeMessage>();
+
+            result.Count().Should().Be(2);
+            result.Should().Contain(x => x is SomeMessageHandlerA<SomeMessage>);
+            result.Should().Contain(x => x is SomeMessageHandlerB<SomeMessage>);
+        }
+
+        [Test]
+        public void WhenTheFirstStrategyHasAMatchingHandlerAndTheSecondStrategyHasTheSameMatchingHandler_ResolverShouldReturnOnlyOneHandler()
+        {
+            var resolver = new UnionOfAllActivatorsActivation(new IHandlerActivationStrategy[] { new HandlerActivationStrategyA { ShouldFindItems = true }, new HandlerActivationStrategyA { ShouldFindItems = true } });
+            var result = resolver.GetHandlers<SomeMessage>();
+
+            result.Count().Should().Be(1);
+            result.Should().Contain(x => x is SomeMessageHandlerA<SomeMessage>);
+        }
+
+        private class SomeMessage { }
+        private class SomeMessageHandlerA<T> : IHandle<T>
+        {
+            public void Handle(T @event) { }
+            public void OnError(T @event, Exception ex) { }
+        }
+        private class HandlerActivationStrategyA : IHandlerActivationStrategy
+        {
+            public bool ShouldFindItems { get; set; }
+
+            public IEnumerable<IHandle<TEventType>> GetHandlers<TEventType>()
+            {
+                return ShouldFindItems ? new[] { new SomeMessageHandlerA<TEventType>() } : Enumerable.Empty<IHandle<TEventType>>();
+            }
+        }
+
+        private class HandlerActivationStrategyB : IHandlerActivationStrategy
+        {
+            public bool ShouldFindItems { get; set; }
+
+            public IEnumerable<IHandle<TEventType>> GetHandlers<TEventType>()
+            {
+                return ShouldFindItems ? new[] { new SomeMessageHandlerB<TEventType>() } : Enumerable.Empty<IHandle<TEventType>>();
+            }
+        }
+        private class SomeMessageHandlerB<T> : IHandle<T>
+        {
+            public void Handle(T @event) { }
+            public void OnError(T @event, Exception ex) { }
+        }
+    }
+}

--- a/ReallySimpleEventing.Test.Unit/ReallySimpleEventing.Test.Unit.csproj
+++ b/ReallySimpleEventing.Test.Unit/ReallySimpleEventing.Test.Unit.csproj
@@ -47,7 +47,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="ActivationStrategies\Activator\DefaultResolverTests.cs" />
+    <Compile Include="ActivationStrategies\Activator\DefaultActivatorTests.cs" />
+    <Compile Include="ActivationStrategies\Composed\UnionOfAllActivatorsActivatorTests.cs" />
+    <Compile Include="ActivationStrategies\Composed\FirstViableActivatorActivatorTests.cs" />
     <Compile Include="ActivationStrategies\Delegated\DelegatedActivatorTests.cs" />
     <Compile Include="EventsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -65,7 +67,6 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/ReallySimpleEventing/ActivationStrategies/Activator/ActivatorActivation.cs
+++ b/ReallySimpleEventing/ActivationStrategies/Activator/ActivatorActivation.cs
@@ -19,9 +19,9 @@ namespace ReallySimpleEventing.ActivationStrategies.Activator
         
         public IEnumerable<IHandle<TEventType>> GetHandlers<TEventType>()
         {
-            var handlerTypes = _eventHandlerResolver.GetHandlerTypesForEvent(typeof (TEventType));
+            var handlers = _eventHandlerResolver.GetHandlerTypesForEvent(typeof (TEventType));
 
-            foreach (var type in handlerTypes)
+            foreach (var type in handlers)
             {
                 yield return (IHandle<TEventType>)System.Activator.CreateInstance(type);
             }

--- a/ReallySimpleEventing/ActivationStrategies/Composed/FirstViableActivatorActivation.cs
+++ b/ReallySimpleEventing/ActivationStrategies/Composed/FirstViableActivatorActivation.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using ReallySimpleEventing.EventHandling;
+
+namespace ReallySimpleEventing.ActivationStrategies.Composed
+{
+    public class FirstViableActivatorActivation : IHandlerActivationStrategy
+    {
+        private readonly IEnumerable<IHandlerActivationStrategy> _activators;
+
+        public FirstViableActivatorActivation(IEnumerable<IHandlerActivationStrategy> activators)
+        {
+            _activators = activators ?? Enumerable.Empty<IHandlerActivationStrategy>();
+        }
+
+        public IEnumerable<IHandle<TEventType>> GetHandlers<TEventType>()
+        {
+            var fallback = Enumerable.Empty<IHandle<TEventType>>();
+
+            foreach (var activator in _activators)
+            {
+                var current = (activator.GetHandlers<TEventType>() ?? fallback).ToList();
+
+                if (current.Any())
+                {
+                    return current;
+                }
+            }
+
+            return fallback;
+        }
+    }
+}

--- a/ReallySimpleEventing/ActivationStrategies/Composed/UnionOfAllActivatorsActivation.cs
+++ b/ReallySimpleEventing/ActivationStrategies/Composed/UnionOfAllActivatorsActivation.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ReallySimpleEventing.EventHandling;
+
+namespace ReallySimpleEventing.ActivationStrategies.Composed
+{
+    public class UnionOfAllActivatorsActivation : IHandlerActivationStrategy
+    {
+        private readonly IEnumerable<IHandlerActivationStrategy> _activators;
+
+        public UnionOfAllActivatorsActivation(IEnumerable<IHandlerActivationStrategy> activators)
+        {
+            _activators = activators ?? Enumerable.Empty<IHandlerActivationStrategy>();
+        }
+
+        public IEnumerable<IHandle<TEventType>> GetHandlers<TEventType>()
+        {
+            var result = new Dictionary<Type, IHandle<TEventType>>();
+
+            foreach (var activator in _activators)
+            {
+                var currentActivator = activator.GetHandlers<TEventType>();
+
+                if (currentActivator != null)
+                {
+                    foreach (var handler in currentActivator)
+                    {
+                        result[handler.GetType()] = handler;//cant use a set as different instances of the same type may have different hash codes
+                    }
+                }
+            }
+
+            return result.Values;
+        }
+    }
+}

--- a/ReallySimpleEventing/ReallySimpleEventing.csproj
+++ b/ReallySimpleEventing/ReallySimpleEventing.csproj
@@ -41,7 +41,9 @@
   <ItemGroup>
     <Compile Include="ActivationStrategies\Activator\ActivatorActivation.cs" />
     <Compile Include="ActivationStrategies\Activator\IEventHandlerResolver.cs" />
+    <Compile Include="ActivationStrategies\Composed\UnionOfAllActivatorsActivation.cs" />
     <Compile Include="ActivationStrategies\Delegated\DelegatedActivation.cs" />
+    <Compile Include="ActivationStrategies\Composed\FirstViableActivatorActivation.cs" />
     <Compile Include="ActivationStrategies\IHandlerActivationStrategy.cs" />
     <Compile Include="EventHandling\IHandleAsync.cs" />
     <Compile Include="TypeExtensions.cs" />


### PR DESCRIPTION
Rearchitected the activation (a few weeks ago)

Recreated the pull request after implementing the fallback activator.  Specifically:
  FirstViableActivatorActivation - given n sub-activators, return the results of the first sucessful subactivator call

UnionOfAllActivatorsActivation - return the set union of all sub-resolvers results

Tests included
